### PR TITLE
Setup DiolBackendService as a dotnet tool

### DIFF
--- a/source/Diol/src/applications/DiolBackendService/DiolBackendService.csproj
+++ b/source/Diol/src/applications/DiolBackendService/DiolBackendService.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>DiolBackendService</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,8 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="setup.ps1">
+    <None Update="ReadME.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="distrib\" />
   </ItemGroup>
 </Project>

--- a/source/Diol/src/applications/DiolBackendService/Pages/Index.cshtml
+++ b/source/Diol/src/applications/DiolBackendService/Pages/Index.cshtml
@@ -9,33 +9,39 @@
 </head>
 <body>
 
-    <h1>Welcome to Diol signal r client</h1>
-
     <section>
-
-        <p>Before starting we need to connect to signal R hub.</p>
-
-        <button id="btn_connect_to_signalr"
-                onclick="connectToSignalR()">
-            Connect to signal r
-        </button>
-        <span id="status_span"></span>
-
+        <h1>Welcome to Diol signal r client</h1>
     </section>
 
     <section>
 
-        <p>Then, we need to connect to the process by id. You can find an id by specific endpoint.</p>
+        <h2>Connect to a process</h2>
 
-        <input id="processId" type="text" />
-        <button id="btn_connect_to_process"
-                onclick="connectToProcess()">
-            Connect to the process
-        </button>
+        <div>
+            <p>Before starting we need to connect to signal R hub.</p>
+
+            <button id="btn_connect_to_signalr"
+                    onclick="connectToSignalR()">
+                Connect to signal r
+            </button>
+            <span id="status_span"></span>
+
+        </div>
+        
+        <div>
+            <p>Then, we need to connect to the process by id. You can find an id by specific endpoint.</p>
+
+            <input id="processId" type="text" />
+            <button id="btn_connect_to_process"
+                    onclick="connectToProcess()">
+                Connect to the process
+            </button>
+        </div>
     </section>
 
     <section>
-        <p>Now new data should come. you can always clear the table</p>
+
+        <h2>Logs</h2>
 
         <button id="btn_clear"
                 onclick="refreshTable()">

--- a/source/Diol/src/applications/DiolBackendService/Program.cs
+++ b/source/Diol/src/applications/DiolBackendService/Program.cs
@@ -4,8 +4,6 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 
-builder.Services.AddWindowsService();
-
 builder.Services.AddDiolWeb();
 builder.Services.AddRazorPages();
 

--- a/source/Diol/src/applications/DiolBackendService/ReadME.md
+++ b/source/Diol/src/applications/DiolBackendService/ReadME.md
@@ -1,0 +1,22 @@
+﻿# DiolBackendService
+
+## How to install
+
+1. Open a `setupAsDotnetTool.ps1` script
+2. Just run step by step the commands in the script
+
+### I want to update the version
+
+In this case please just uninstall the previous version (the command you can find the the ps1 script) and then install the new version (the command you can find in the ps1 script)
+
+```powershell
+
+## How to use
+
+After installation you can run the following command to start the server:
+
+```powershell
+DiolBackendService --urls=http://localhost:62023/
+```
+
+`---urls` can be changed to any port you want to run the server on.

--- a/source/Diol/src/applications/DiolBackendService/setupAsDotnetTool.ps1
+++ b/source/Diol/src/applications/DiolBackendService/setupAsDotnetTool.ps1
@@ -1,0 +1,16 @@
+﻿$packageName = 'DiolBackendService'
+$packagePath = '.\distrib\release\DiolBackendService'
+
+$csProjPath = '.\DiolBackendService.csproj'
+
+# delete old one
+dotnet tool uninstall -g $packageName
+
+# pack and install
+dotnet build -c Release
+dotnet pack $csProjPath --output $packagePath
+dotnet tool install --global --add-source $packagePath $packageName
+
+# how to use
+# from a terminal please run the following command:
+# DiolBackendService --urls=http://localhost:62023/


### PR DESCRIPTION
#53 

The updates allow users to easily setup DiolBackendService as a dotnet tool and use it from the terminal.